### PR TITLE
Terraform version + unneeded argument

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -17,7 +17,6 @@
 
 data "aws_route53_zone" "selected" {
   zone_id = var.dns_hosted_zone_id
-  vpc_id  = var.vpc_id
 }
 
 # Locals block for DNS management.

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.17"
 
   required_providers {
     aws = ">= 2.38.0"


### PR DESCRIPTION
- set fixed terraform version for using trim function
- remove unneeded vpc_id argument