### PR TITLE
Add possibility to use a certificate that already exists in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ For internal services with restricted access (api, grafana, weave…):
 
 The following resources are also created, and are common to external and internal services:
 - rules are added to the cluster’s security group to allow the ALB to join the services’ NodePorts.
-- a TLS certificate, in AWS Certificate Manager, with the domain name “*.<cluster_name>.<hosted_zone>”
+- (optional) a TLS certificate, in AWS Certificate Manager, with the domain name “*.<cluster_name>.<hosted_zone>”
+
+The TLS certificate can be created by this module (it will be issued and validated in AWS Certificate Manager), or a certificate already existing in ACM can be specified.
 
 
 ## Usage example

--- a/loadbalancer_private.tf
+++ b/loadbalancer_private.tf
@@ -141,7 +141,7 @@ resource "aws_lb_listener" "quortex_private_tls" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = var.private_lb_ssl_policy
-  certificate_arn   = aws_acm_certificate.cert.arn
+  certificate_arn   = var.ssl_certificate_arn == null ? aws_acm_certificate.cert[0].arn : var.ssl_certificate_arn
 
   default_action {
     type             = "forward"

--- a/loadbalancer_public.tf
+++ b/loadbalancer_public.tf
@@ -141,7 +141,7 @@ resource "aws_lb_listener" "quortex_public_tls" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = var.public_lb_ssl_policy
-  certificate_arn   = aws_acm_certificate.cert.arn
+  certificate_arn   = var.ssl_certificate_arn == null ? aws_acm_certificate.cert[0].arn : var.ssl_certificate_arn
 
   default_action {
     type             = "forward"

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "public_lb_target_group_name" {
 
 variable "ssl_certificate_name" {
   type        = string
-  description = "Name of the SSL certificate"
+  description = "Name of the SSL certificate.  Not used if an existing certificate ARN is provided."
   default     = "quortex"
 }
 
@@ -119,9 +119,16 @@ variable "dns_records_public" {
   default     = {}
 }
 
+variable "ssl_certificate_arn" {
+  type        = string
+  description = "The ARN identifier of an existing Certificate in AWS Certificate Manager, to be used for HTTPS requests. If not defined, a new certificate will be issued and validated in the AWS Certificate Manager."
+  default     = null
+}
+
 variable "ssl_certificate_subdomain" {
   type        = string
-  description = "The subdomain name that will be written in the TLS certificate. Can include a wildcard. The hosted zone name will be appended to form the complete domain name."
+  description = "The subdomain name that will be written in the TLS certificate. Can include a wildcard. The hosted zone name will be appended to form the complete domain name. Not used if an existing certificate ARN is provided."
+  default     = null
 }
 
 variable "tags" {


### PR DESCRIPTION
Instead of issueing and validating a new certificate.