### PR TITLE
Make DNS hosted zone optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module "load-balancer" {
   load_balancer_private_app_backend_ports = [var.service_nodeport_private]
 
   # SSL configuration.
-  ssl_certificate_subdomain               = "*.domain"
+  ssl_certificate_domain_name             = "*.mydomain.com"
     
   # DNS configuration.
   dns_hosted_zone_id                      = var.hosted_zone_id

--- a/dns.tf
+++ b/dns.tf
@@ -16,6 +16,8 @@
 
 
 data "aws_route53_zone" "selected" {
+  count = var.dns_hosted_zone_id == null ? 0 : 1
+
   zone_id = var.dns_hosted_zone_id
 }
 
@@ -30,7 +32,7 @@ locals {
 resource "aws_route53_record" "quortex_public" {
   for_each = var.dns_records_public
 
-  zone_id = data.aws_route53_zone.selected.zone_id
+  zone_id = data.aws_route53_zone.selected[0].zone_id
   name    = each.value
   type    = "A"
 
@@ -45,7 +47,7 @@ resource "aws_route53_record" "quortex_public" {
 resource "aws_route53_record" "quortex_private" {
   for_each = var.dns_records_private
 
-  zone_id = data.aws_route53_zone.selected.zone_id
+  zone_id = data.aws_route53_zone.selected[0].zone_id
   name    = each.value
   type    = "A"
 

--- a/ssl.tf
+++ b/ssl.tf
@@ -18,7 +18,7 @@
 resource "aws_acm_certificate" "cert" {
   count = var.ssl_certificate_arn == null ? 1 : 0
 
-  domain_name       = join(".", [var.ssl_certificate_subdomain, trimsuffix(data.aws_route53_zone.selected.name, ".")]) # concatenate subdomain and hosted zone name
+  domain_name       = var.ssl_certificate_domain_name
   validation_method = "DNS"
 
   tags = merge({
@@ -37,7 +37,7 @@ resource "aws_route53_record" "cert_validation" {
 
   name    = aws_acm_certificate.cert[0].domain_validation_options.0.resource_record_name
   type    = aws_acm_certificate.cert[0].domain_validation_options.0.resource_record_type
-  zone_id = data.aws_route53_zone.selected.zone_id
+  zone_id = data.aws_route53_zone.selected[0].zone_id
   records = [aws_acm_certificate.cert[0].domain_validation_options.0.resource_record_value]
   ttl     = 60
 }

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,8 @@ variable "load_balancer_autoscaling_group_names" {
 
 variable "dns_hosted_zone_id" {
   type        = string
-  description = "The ID of the hosted zone in Route53, under which the DNS record should be created."
+  description = "The ID of the hosted zone in Route53, under which the DNS record should be created. Can be null if no DNS records need to be created. Required if ssl_certificate_arn is null, to validate the certificate created by this module."
+  default     = null
 }
 
 variable "dns_records_private" {
@@ -125,9 +126,9 @@ variable "ssl_certificate_arn" {
   default     = null
 }
 
-variable "ssl_certificate_subdomain" {
+variable "ssl_certificate_domain_name" {
   type        = string
-  description = "The subdomain name that will be written in the TLS certificate. Can include a wildcard. The hosted zone name will be appended to form the complete domain name. Not used if an existing certificate ARN is provided."
+  description = "The complete domain name that will be written in the TLS certificate. Can include a wildcard. Not used if an existing certificate ARN is provided."
   default     = null
 }
 


### PR DESCRIPTION
We can now skip DNS setup by setting dns_hosted_zone_id to null, and dns_records_private and dns_records_public to an empty map.

As a consequence, we must now pass the domain name to the ssl_certificate_domain_name variable for the certificate, since the domain name can no longer be retrieved from the hosted zone.

[API breaking change]