### PR TITLE
Fix failing target group updates

### DIFF
--- a/loadbalancer_private.tf
+++ b/loadbalancer_private.tf
@@ -91,7 +91,6 @@ resource "aws_lb_target_group" "quortex_private" {
   # No target group will be created (yet) if the no port is defined
   count = length(var.load_balancer_private_app_backend_ports) > 0 ? 1 : 0
 
-  name   = local.private_lb_target_group_name
   vpc_id = var.vpc_id
 
   target_type = "instance"
@@ -125,6 +124,11 @@ resource "aws_lb_target_group" "quortex_private" {
     },
     var.tags
   )
+
+  # workaround for failing target group modifications
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Listeners for the ALB

--- a/loadbalancer_public.tf
+++ b/loadbalancer_public.tf
@@ -100,7 +100,6 @@ resource "aws_lb_target_group" "quortex_public" {
   # No target group will be created (yet) if the no port is defined
   count = length(var.load_balancer_public_app_backend_ports) > 0 ? 1 : 0
 
-  name   = local.public_lb_target_group_name
   vpc_id = var.vpc_id
 
   target_type = "instance"
@@ -133,7 +132,12 @@ resource "aws_lb_target_group" "quortex_public" {
     Name = local.public_lb_target_group_name
     },
     var.tags
-  )
+  )  
+
+  # workaround for failing target group modifications
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Listeners for the ALB


### PR DESCRIPTION
Target group updates were failing with the following message: "target group is currently in use by a listener or a rule"

Using create_before_destroy is a workaround for this issue.

As a consequence, we also need to remove the name for the target groups. Otherwise, the creation fails because the name already exists.