### PR TITLE
Fix warning about deprecated interpolation syntax

### DIFF
--- a/resource_names.tf
+++ b/resource_names.tf
@@ -21,7 +21,7 @@ locals {
   public_lb_security_group_name  = length(var.public_lb_security_group_name) > 0 ? var.public_lb_security_group_name : "${var.resource_name}-pub"
   public_lb_name                 = length(var.public_lb_name) > 0 ? var.public_lb_name : "${var.resource_name}-pub"
   public_lb_target_group_name    = length(var.public_lb_target_group_name) > 0 ? var.public_lb_target_group_name : "${var.resource_name}-pub"
-  ssl_certificate_name           = length(var.ssl_certificate_name) > 0 ? var.ssl_certificate_name : "${var.resource_name}"
-  cdn_distribution_name          = length(var.cdn_distribution_name) > 0 ? var.cdn_distribution_name : "${var.resource_name}"
+  ssl_certificate_name           = length(var.ssl_certificate_name) > 0 ? var.ssl_certificate_name : var.resource_name
+  cdn_distribution_name          = length(var.cdn_distribution_name) > 0 ? var.cdn_distribution_name : var.resource_name
   cdn_ssl_certificate_name       = length(var.cdn_ssl_certificate_name) > 0 ? var.cdn_ssl_certificate_name : "${var.resource_name}-cdn"
 }


### PR DESCRIPTION
There was a warning with terraform 0.14: "Warning: Interpolation-only expressions are deprecated"