### PR TITLE
Fix/cdn validation syntax

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -102,7 +102,7 @@ resource "aws_cloudfront_distribution" "lb_distribution" {
 
   # TLS configuration
   viewer_certificate {
-    acm_certificate_arn            = var.cdn_ssl_certificate_arn != null ? var.cdn_ssl_certificate_arn : aws_acm_certificate_validation.cert_cdn[0].certificate_arn
+    acm_certificate_arn            = var.cdn_ssl_certificate_arn != null ? var.cdn_ssl_certificate_arn : values(aws_acm_certificate_validation.cert_cdn)[0].certificate_arn
     cloudfront_default_certificate = false
     minimum_protocol_version       = "TLSv1.2_2019"
     ssl_support_method             = "sni-only"

--- a/loadbalancer_private.tf
+++ b/loadbalancer_private.tf
@@ -145,7 +145,7 @@ resource "aws_lb_listener" "quortex_private_tls" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = var.private_lb_ssl_policy
-  certificate_arn   = var.ssl_certificate_arn == null ? aws_acm_certificate_validation.cert[0].certificate_arn : var.ssl_certificate_arn
+  certificate_arn   = var.ssl_certificate_arn == null ? values(aws_acm_certificate_validation.cert)[0].certificate_arn : var.ssl_certificate_arn
 
   default_action {
     type             = "forward"

--- a/loadbalancer_public.tf
+++ b/loadbalancer_public.tf
@@ -154,7 +154,7 @@ resource "aws_lb_listener" "quortex_public_tls" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = var.public_lb_ssl_policy
-  certificate_arn   = var.ssl_certificate_arn == null ? aws_acm_certificate_validation.cert[0].certificate_arn : var.ssl_certificate_arn
+  certificate_arn   = var.ssl_certificate_arn == null ? values(aws_acm_certificate_validation.cert)[0].certificate_arn : var.ssl_certificate_arn
 
   default_action {
     type             = "forward"

--- a/ssl.tf
+++ b/ssl.tf
@@ -38,21 +38,26 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 
+locals {
+  # Convert to a map, referenced by the certificate's ARN
+  certs = { for c in aws_acm_certificate.cert : c.arn => c }
+}
+
 # DNS record to validate this certificate
 resource "aws_route53_record" "cert_validation" {
-  count = var.ssl_certificate_arn == null ? 1 : 0
+  for_each = local.certs
 
-  name    = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_name
-  type    = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_type
+  name    = tolist(each.value.domain_validation_options)[0].resource_record_name
+  type    = tolist(each.value.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.selected[0].zone_id
-  records = [tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_value]
+  records = [tolist(each.value.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 
 # Certificate validation
 resource "aws_acm_certificate_validation" "cert" {
-  count = var.ssl_certificate_arn == null ? 1 : 0
+  for_each = local.certs
 
-  certificate_arn         = aws_acm_certificate.cert[0].arn
-  validation_record_fqdns = [aws_route53_record.cert_validation[0].fqdn]
+  certificate_arn         = each.value.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation[each.key].fqdn]
 }

--- a/ssl.tf
+++ b/ssl.tf
@@ -42,10 +42,10 @@ resource "aws_acm_certificate" "cert" {
 resource "aws_route53_record" "cert_validation" {
   count = var.ssl_certificate_arn == null ? 1 : 0
 
-  name    = aws_acm_certificate.cert[0].domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.cert[0].domain_validation_options.0.resource_record_type
+  name    = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.selected[0].zone_id
-  records = [aws_acm_certificate.cert[0].domain_validation_options.0.resource_record_value]
+  records = [tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 

--- a/ssl_cdn.tf
+++ b/ssl_cdn.tf
@@ -41,10 +41,10 @@ resource "aws_route53_record" "cert_validation_cdn" {
   count = (var.cdn_create_distribution && var.cdn_ssl_certificate_arn == null && var.cdn_dns_record != null) ? 1 : 0
 
   provider = aws.us-east-1 # the certificate used in CloudFront CDN has to be located in th "us-east-1" (N. Virginia) region
-  name     = aws_acm_certificate.cert_cdn[0].domain_validation_options.0.resource_record_name
-  type     = aws_acm_certificate.cert_cdn[0].domain_validation_options.0.resource_record_type
+  name     = tolist(aws_acm_certificate.cert_cdn[0].domain_validation_options)[0].resource_record_name
+  type     = tolist(aws_acm_certificate.cert_cdn[0].domain_validation_options)[0].resource_record_type
   zone_id  = data.aws_route53_zone.selected[0].zone_id
-  records  = [aws_acm_certificate.cert_cdn[0].domain_validation_options.0.resource_record_value]
+  records  = [tolist(aws_acm_certificate.cert_cdn[0].domain_validation_options)[0].resource_record_value]
   ttl      = 60
 }
 


### PR DESCRIPTION
/!\ This branch is based on the tag 1.2.1 

contains 2 proposals:

**Fix certificate validation with latest AWS provider versions**

The field "domain_validation_options" is now a set instead of a list, in newer versions of the AWS provider.

So the set needs to be converted to a list in order to be referenced by index 0.

The change is compatible with older versions of the provider.
 
**More robust certificate declaration**

The conditional declaration of the certificate DNS record and validation object with "count" was causing issues on updates.

Using a for_each on a map, indexed by the certificate ARN should be more robust.

(may trigger a re-validation of th existing certificate)