### PR TITLE
Adding an option to add Origin Shield range.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,12 @@ variable "load_balancer_public_whitelisted_ips" {
   default     = []
 }
 
+variable "load_balancer_public_allow_origin_shield_range" {
+  type        = bool
+  description = "Should Origin Shield IP range be allowed on ingress on public LB."
+  default     = false
+}
+
 variable "load_balancer_autoscaling_group_names" {
   type        = list(string)
   description = "The name of the autoscaling groups containing the target instances, so that instances can be attached to the load balancer's target group."


### PR DESCRIPTION
Adding an option to add Cloudfront Origin Shield IP range to public LB ingress rules.
Note that, this variable is not documented by AWS. So this is a best guess. Tests are successful though, but lot of Cloudfront and Origin Shield IP range overlap, so I was able to prove that this range is truly and only dedicated to Origin Shield.

Also, note that resulting SG will contain ~170 rules.