### PR TITLE
Use for_each to index aws_autoscaling_attachment

### DIFF
--- a/target_groups.tf
+++ b/target_groups.tf
@@ -20,24 +20,30 @@
 locals {
   # We create an attachment for each autoscaling_group / target_group
   # combination in order to best distribute the load in the cluster.
-  quortex_public_attachments  = flatten([for asg_name in var.load_balancer_autoscaling_group_names : [for target_group in aws_lb_target_group.quortex_public : { "target_group_arn" : target_group.arn, "asg_name" : asg_name }]])
-  quortex_private_attachments = flatten([for asg_name in var.load_balancer_autoscaling_group_names : [for target_group in aws_lb_target_group.quortex_private : { "target_group_arn" : target_group.arn, "asg_name" : asg_name }]])
+  quortex_public_attachments = {
+    for c in setproduct(aws_lb_target_group.quortex_public.*.arn, var.load_balancer_autoscaling_group_names) :
+    "${c.0}_${c.1}" => { "target_group_arn" : c.0, "asg_name" : c.1 }
+  }
+  quortex_private_attachments = {
+    for c in setproduct(aws_lb_target_group.quortex_private.*.arn, var.load_balancer_autoscaling_group_names) :
+    "${c.0}_${c.1}" => { "target_group_arn" : c.0, "asg_name" : c.1 }
+  }
 }
 
 # Attach the autoscaling groups to the public ALB target groups
 resource "aws_autoscaling_attachment" "quortex_public" {
   # No target group will be created if backend port is not defined
-  count = var.load_balancer_autoscaling_group_count * length(var.load_balancer_public_app_backend_ports)
+  for_each = length(var.load_balancer_public_app_backend_ports) > 0 ? local.quortex_public_attachments : {}
 
-  autoscaling_group_name = local.quortex_public_attachments[count.index].asg_name
-  lb_target_group_arn   = local.quortex_public_attachments[count.index].target_group_arn
+  autoscaling_group_name = each.value.asg_name
+  lb_target_group_arn   = each.value.target_group_arn
 }
 
 # Attach the autoscaling groups to the private ALB target groups
 resource "aws_autoscaling_attachment" "quortex_private" {
   # No target group will be created if backend port is not defined
-  count = var.load_balancer_autoscaling_group_count * length(var.load_balancer_private_app_backend_ports)
+  for_each = length(var.load_balancer_private_app_backend_ports) > 0 ? local.quortex_private_attachments : {}
 
-  autoscaling_group_name = local.quortex_private_attachments[count.index].asg_name
-  lb_target_group_arn   = local.quortex_private_attachments[count.index].target_group_arn
+  autoscaling_group_name = each.value.asg_name
+  lb_target_group_arn   = each.value.target_group_arn
 }


### PR DESCRIPTION
Breaking, will need to move manually in the terraform state all "module.main.module.load-balancer.aws_autoscaling_attachment.quortex_public[<idx>]" to "module.main.module.load-balancer.aws_autoscaling_attachment.quortex_public["<targetgroup_arn>_<asg_name>"]"

To execute this migration i made this script : [convert_state.py.zip](https://github.com/quortex/terraform-aws-load-balancer/files/10196466/convert_state.py.zip)

To use it
 * Pull old state with `terraform state pull > old.tfstate`
 * Convert it with `python3 convert_state.py old.tfstate new.tfstate`
 * Check that the changes are correct with `diff old.tfstate new.tfstate`
 * Push it state with `terraform state push new.tfstate`
 * Then use `terraform plan` to check everything is correct