### PR TITLE
Fix resources creation issue with for_each

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -170,14 +170,9 @@ variable "load_balancer_public_whitelisted_ips" {
   default     = []
 }
 
-variable "load_balancer_autoscaling_group_names" {
-  type        = list(string)
-  description = "The name of the autoscaling groups containing the target instances, so that instances can be attached to the load balancer's target group."
-}
-
-variable "load_balancer_autoscaling_group_count" {
-  type        = number
-  description = "The number of autoscaling groups to be attached to LB."
+variable "load_balancer_autoscaling_groups" {
+  type        = map(string)
+  description = "A map associating a key to the name of the autoscaling groups containing the target instances, so that instances can be attached to the load balancer's target group. The keys must be known before apply."
 }
 
 variable "dns_hosted_zone_id" {


### PR DESCRIPTION
We had two issues with the previous commit which introduced using for_each to avoid recreating all ASGs when a single ASG was added or deleted : the target_group_arn and the autoscaling_group_name are unknown during apply thus they cannot be used as a key of the for_each.

The solution is to use the port index instead of the target_group_arn, and the autoscaling group key (user provided) instead of the autoscaling group name (generated by AWS).

This will unfortunately re-break the state and heavily complexify the migration script : 
[convert_state_v3_1.py.zip](https://github.com/quortex/terraform-aws-load-balancer/files/10578059/convert_state_v3_1.py.zip)
