### PR TITLE
Fix a panic in convert_state_v4 when fields were missing 

### DIFF
--- a/scripts/convert_state_v4.py
+++ b/scripts/convert_state_v4.py
@@ -41,7 +41,7 @@ def filter_resources(**kwargs):
     return (
         resource
         for resource in state["resources"]
-        if all(resource[k] == v for k, v in kwargs.items())
+        if all(resource.get(k) == v for k, v in kwargs.items())
     )
 
 


### PR DESCRIPTION
E.g. the field "module" was not present in all resources.