### PR TITLE
Remove specials from random password

### DIFF
--- a/loadbalancer_public.tf
+++ b/loadbalancer_public.tf
@@ -36,7 +36,7 @@ locals {
 # Random password set into x-auth-token
 resource "random_password" "x_auth_token" {
   length  = 128
-  special = true
+  special = false
 }
 
 # Security group


### PR DESCRIPTION
Remove specials from random password to avoid a bug when a "*" char is used. 